### PR TITLE
Added basic CI with Travis testing CRAN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+
+dist: xenial
+language: R
+sudo: required
+addons:
+  apt:
+    packages:
+      - libnode-dev
+      - valgrind
+r:
+  - oldrel
+  - release
+  - devel
+r_packages:
+ - DiagrammeRsvg
+cache: packages
+latex: false
+r_check_args: "--as-cran --use-valgrind"


### PR DESCRIPTION
With the C++ code added (and in general) it is nice to have Travis CI doing the CRAN checks automatically. @gertjanssenswillen you need to also activate it here:
https://travis-ci.org/bupaverse