### PR TITLE
Fix typo docs trace explorer

### DIFF
--- a/R/trace_explorer.R
+++ b/R/trace_explorer.R
@@ -6,7 +6,7 @@
 #' @param type Frequent traces first, or infrequent traces first?
 #' @param coverage The percentage coverage of the trace to explore. Default is 20\% most (in)frequent
 #' @param n_traces Instead of setting coverage, you can set an exact number of traces. Should be an integer larger than 0.
-#' @param raw_data Retrun raw data
+#' @param raw_data Return raw data
 #' @param .abbreviate If TRUE, abbreviate activity labels
 #' @param show_labels If False, activity labels are not shown.
 #' @param label_size Font size of labels

--- a/docs/reference/trace_explorer.html
+++ b/docs/reference/trace_explorer.html
@@ -144,7 +144,7 @@
     </tr>
     <tr>
       <th>raw_data</th>
-      <td><p>Retrun raw data</p></td>
+      <td><p>Return raw data</p></td>
     </tr>
     </table>
     


### PR DESCRIPTION
Fix a typo ('retrun' instead of 'return') in the documentation for the `trace_explorer` function.