### PR TITLE
Speed up process_map function by using data.table

### DIFF
--- a/R/process_map.R
+++ b/R/process_map.R
@@ -162,22 +162,26 @@ process_map.eventlog <- function(log,
 			as.data.frame() -> base_log
 	}
 
-	#create end points for graph
+	#create end points for graph using data.table slicing
+	dt <- as.data.table(base_log)
+	#set correct ordering within groups
+	data.table::setorder(dt, CASE_CLASSIFIER_, start_time, min_order, na.last=TRUE)
+	#specifying order of columns to reorder end_points_start and end_points_end 
+	colorder <- c('ACTIVITY_CLASSIFIER_', 'ACTIVITY_INSTANCE_CLASSIFIER_', 'CASE_CLASSIFIER_', 'start_time', 'end_time', 'min_order')
+	
+	end_points_start <- dt[, .SD[1], by = CASE_CLASSIFIER_]
+	end_points_start[, min_order := as.numeric(min_order)] #prevents warning when setting value to -Inf
+	end_points_start[, `:=`(ACTIVITY_CLASSIFIER_ = "ARTIFICIAL_START",
+							end_time = start_time,
+							min_order = -Inf)]
+	data.table::setcolorder(end_points_start, colorder)
 
-	base_log %>%
-		group_by(CASE_CLASSIFIER_) %>%
-		arrange(start_time, min_order) -> points_temp
-
-	points_temp %>%
-		slice(1) %>%
-		mutate(ACTIVITY_CLASSIFIER_ = "ARTIFICIAL_START",
-			   end_time = start_time,
-			   min_order = -Inf) -> end_points_start
-	points_temp %>%
-		slice(n()) %>%
-		mutate(ACTIVITY_CLASSIFIER_ = "ARTIFICIAL_END",
-			   start_time = end_time,
-			   min_order = Inf) -> end_points_end
+	end_points_end <- dt[, .SD[.N], by = CASE_CLASSIFIER_]
+	end_points_end[, min_order := as.numeric(min_order)] #prevents warning when setting value to Inf
+	end_points_end[, `:=`(ACTIVITY_CLASSIFIER_ = "ARTIFICIAL_END",
+						  start_time = end_time,
+						  min_order = Inf)]
+	data.table::setcolorder(end_points_end, colorder)
 
 	#add endpoints to base log
 
@@ -185,6 +189,10 @@ process_map.eventlog <- function(log,
 		bind_rows(end_points_start, end_points_end, base_log) %>%
 			ungroup() -> base_log
 	)
+	
+	#converting ACTIVITY_CLASSIFIER_ to character to keep `base_log` identical to the previous dplyr method
+	base_log <- base_log %>%
+				mutate(ACTIVITY_CLASSIFIER_ = as.character(ACTIVITY_CLASSIFIER_))
 
 	#create base nodes list
 


### PR DESCRIPTION
The `process_map` function felt a bit slow, so I rewrote parts of it to try and speed it up. Based on the `profvis` profiling output, I replaced the `dplyr` style slicing with data.table methods, but kept the output exactly the same (column order, sorting).  

I used `microbenchmark` to runs `process_map(data)` 50 times and report how much less time it took (median time) to run the new version compared to the old. The resulting speed up is dependent on the data set:
* `sepsis` takes ~33% less time
* `patients` takes ~34% less time 
* `hospital_billings` takes ~70% less time (from 1525 ms to 459ms)
* `traffic_fines` takes ~72% less time (from 1457ms to 395ms)

On my real life dataset containing almost 200,000 rows it takes ~30% less time to run `process_map(data, frequency('absolute-case'))` (from 32s to 21s). The benchmark on the real life dataset was run on a different device than the example datasets.